### PR TITLE
Add manual Markdown documentation for src/atom_mod.F

### DIFF
--- a/docs/markdown/atom_mod.md
+++ b/docs/markdown/atom_mod.md
@@ -1,0 +1,105 @@
+# atom_mod.F - Code Documentation
+
+## Overview
+
+The `atom_mod.F` file defines a Fortran module named `atom_mod`. This module serves as a central repository for various parameters, constants, and allocatable arrays used throughout the application, particularly those related to atomic structures, basis sets, potentials, and densities. It appears to consolidate data structures that describe the properties and state of atoms within the computational model.
+
+## Key Components
+
+### Modules Used
+
+*   None explicitly used within this module (it defines `atom_mod`). Other modules in the project would `use atom_mod`.
+
+### Subroutines/Functions Defined
+
+*   None defined in this module.
+
+## Important Variables/Constants
+
+This module primarily consists of variable declarations. Below is a partial list, categorized by type. Due to the large number, only a selection is highlighted. Many are allocatable arrays, indicating they store collections of data whose size is determined at runtime.
+
+**Integer Parameters (Selected):**
+*   **`limlb`**: *Likely a limit related to angular momentum or basis functions.*
+*   **`max_bs`**: *Likely a maximum number of basis states.*
+*   **`maxel`**: *Likely a maximum number of electrons or electronic shells.*
+*   **`maxlfun`**: *Maximum number of L-functions (angular momentum functions).*
+*   **`maxmt`**: *Likely related to muffin-tin spheres or a maximum number of such regions.*
+*   **`maxnrad`**: *Maximum number of radial grid points.*
+*   **`nspin`**: *Number of spin polarizations (implicitly, though not declared here, used in array dimensions elsewhere, e.g., `sig_c_omega` in `a_cont_coeff.F`). Assumed to be available from another module.*
+*   *(...and many others)*
+
+**Real*8 Parameters (Selected):**
+*   **`a_const_ci`**: *A constant, possibly related to configuration interaction.*
+
+**Character Variables (Allocatable):**
+*   **`correlated(:,:,:)` (character*1)**: *Likely flags or identifiers for correlated orbitals/states.*
+*   **`augm(:,:,:)` (character*3)**: *Likely related to augmentation methods or augmented wave basis sets.*
+*   **`txtel(:)` (character*4)**: *Text identifiers for electronic levels or shells.*
+
+**Integer Arrays (Allocatable, Selected Examples):**
+*   **`i_num(:)`**: *Generic integer numbers or indices.*
+*   **`idmd(:,:,:)`**: *Indices or identifiers, possibly related to density matrices or dimensions.*
+*   **`ind_ci(:)`**: *Indices for configuration interaction.*
+*   **`konfig(:,:)`**: *Configurations, likely electronic configurations.*
+*   **`lfun(:)`**: *Angular momentum quantum numbers for functions.*
+*   **`ncor(:)`**: *Number of core states/electrons.*
+*   **`nrad(:)`**: *Number of radial points for different atoms or shells.*
+*   *(...and many others)*
+
+**Real*8 Arrays (Allocatable, Selected Examples):**
+*   **`augm_coef(:,:,:,:)`**: *Coefficients for augmentation.*
+*   **`amass(:)`**: *Atomic masses.*
+*   **`atoc(:,:,:)`**: *Atomic orbital coefficients or similar.*
+*   **`e_core(:,:,:)`**: *Core electron energies.*
+*   **`elda_atom(:,:,:)`**: *Electron density (LDA) for atoms.*
+*   **`r(:,:)`**: *Radial grid points.*
+*   **`ro(:)`**: *Radial parts of densities or wavefunctions.*
+*   **`v_at(:,:,:)`**: *Atomic potentials.*
+*   **`z(:)`**: *Atomic numbers (charges).*
+*   *(...and many others)*
+
+**Complex*16 Arrays (Allocatable, Selected Examples):**
+*   **`g_omega_atom(:,:,:,:,:)`**: *Frequency-dependent Green's functions for atoms.*
+*   **`sigc_omega_atom(:,:,:,:,:)`**: *Frequency-dependent correlation part of self-energy for atoms.*
+*   *(...and a few others)*
+
+
+## Usage Examples
+
+This module is not directly "used" in terms of calling functions from it, as it primarily provides data structures. Other parts of the code would use this module to access these variables.
+
+```fortran
+module another_calculation_mod
+  use atom_mod
+  implicit none
+
+  subroutine calculate_something()
+    integer :: i, j
+    real*8 :: total_energy
+
+    ! Example: Accessing variables from atom_mod
+    if (maxel > 0) then
+      do i = 1, n_some_dimension ! Assuming n_some_dimension is defined
+        do j = 1, n_other_dimension ! Assuming n_other_dimension is defined
+          ! Access an array from atom_mod, e.g., e_core
+          ! Ensure indices are within bounds based on other variables from atom_mod
+          ! total_energy = total_energy + e_core(i, j, 1) ! Example access
+        end do
+      end do
+    end if
+
+    ! ... further calculations ...
+  end subroutine calculate_something
+
+end module another_calculation_mod
+```
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:** This module itself does not depend on other custom modules from this project via `use` statements. It is a foundational module that provides data definitions.
+*   **External Libraries:** No external libraries are directly used in this module's definition.
+*   **Interactions:** This module is crucial for many other modules in the system. Any module performing calculations involving atomic properties, electronic structure, potentials, or basis sets would likely `use atom_mod` to access the declared variables. The consistency and correct population of these variables are vital for the overall application's correctness.
+
+---
+*Documentation generated manually by AI assistant due to script execution issues. Please review and enhance.*
+```

--- a/generate_doc.py
+++ b/generate_doc.py
@@ -1,0 +1,236 @@
+import argparse
+import os
+import re
+
+def parse_fortran_file(filepath):
+    """
+    Parses a Fortran file to extract modules, subroutines, functions, and variables.
+    """
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: File not found at {filepath}")
+        return None
+    except Exception as e:
+        print(f"Error reading file {filepath}: {e}")
+        return None
+
+    # Remove comments (lines starting with c, *, or !)
+    # Process line continuations (&) by joining lines. This is a simplified approach.
+    processed_lines = []
+    for line in content.splitlines():
+        stripped_line = line.strip()
+        if stripped_line.startswith(('c', '*', '!')):
+            continue
+        if processed_lines and processed_lines[-1].endswith('&'):
+            processed_lines[-1] = processed_lines[-1][:-1] + stripped_line
+        else:
+            processed_lines.append(stripped_line)
+
+    clean_content = "\n".join(processed_lines)
+
+    # Extract file base name
+    file_name = os.path.basename(filepath)
+
+    # Regex patterns (simplified for common cases)
+    module_use_pattern = re.compile(r"^\s*use\s+([a-z0-9_]+)", re.IGNORECASE | re.MULTILINE)
+    subroutine_pattern = re.compile(
+        r"^\s*subroutine\s+([a-z0-9_]+)\s*(?:\((.*?)\))?",
+        re.IGNORECASE | re.MULTILINE
+    )
+    # Fortran function patterns can be complex due to optional type prefixes and result clauses
+    function_pattern = re.compile(
+        r"^\s*(?:(?:real|integer|character|logical|double\s*precision|complex)(?:\s*\(.*?\))?\s+)?function\s+([a-z0-9_]+)\s*\((.*?)\)\s*(?:result\s*\((.*?)\))?",
+        re.IGNORECASE | re.MULTILINE
+    )
+
+    # Module-level variable declarations (very simplified)
+    # This will capture lines like: type :: var1, var2 or type, intent(in) :: var
+    # It doesn't distinguish between module scope and local scope perfectly without full parsing.
+    # We'll try to refine this by looking for declarations outside subroutines/functions.
+
+    # First, find module blocks
+    module_blocks_matches = list(re.finditer(r"^\s*module\s+([a-z0-9_]+)\s*$(.*?)^\s*end\s*module\s+\1", clean_content, re.IGNORECASE | re.MULTILINE | re.DOTALL))
+
+    module_variables = []
+    if module_blocks_matches:
+        for mod_match in module_blocks_matches:
+            module_content = mod_match.group(2)
+            # Remove subroutines and functions from module content to isolate module-level variables
+            module_content_no_subs_funcs = re.sub(subroutine_pattern, "", module_content)
+            module_content_no_subs_funcs = re.sub(function_pattern, "", module_content_no_subs_funcs)
+
+            # Look for variable declarations: type :: var, type, attr :: var
+            # This is a very basic pattern and might need significant improvement.
+            var_decl_pattern = re.compile(
+                r"^\s*(real|integer|character|logical|double\s*precision|complex|type\s*\(.*?\))\s*(?:,\s*[^:]+)?::\s*([a-z0-9_,\s()]+)",
+                re.IGNORECASE | re.MULTILINE
+            )
+            for var_match in var_decl_pattern.finditer(module_content_no_subs_funcs):
+                var_type = var_match.group(1).strip()
+                var_names_str = var_match.group(2).strip()
+                # Split variable names, handling array dimensions like var(dim)
+                raw_names = [name.strip().split('(')[0] for name in var_names_str.split(',')]
+                for name in raw_names:
+                    if name: # Ensure not empty string
+                        module_variables.append({"name": name, "type": var_type})
+
+    modules_used = sorted(list(set(module_use_pattern.findall(clean_content))))
+
+    subroutines = []
+    for match in subroutine_pattern.finditer(clean_content):
+        name = match.group(1)
+        args_str = match.group(2)
+        args = [arg.strip() for arg in args_str.split(',') if arg.strip()] if args_str else []
+        subroutines.append({"name": name, "args": args})
+
+    functions = []
+    for match in function_pattern.finditer(clean_content):
+        name = match.group(1)
+        args_str = match.group(2)
+        args = [arg.strip() for arg in args_str.split(',') if arg.strip()] if args_str else []
+        # Return type might be part of the declaration (group before function name) or result clause
+        # This regex doesn't fully capture the type prefix yet, needs refinement.
+        # For now, we'll placeholder the return type.
+        return_type = "unknown" # Placeholder
+        if match.group(3): # result(var_name)
+            return_type = f"result({match.group(3)})"
+        # elif match.group(1) contains type: # This part of regex needs to be structured to capture prefix
+        #    return_type = match.group(1).strip() # Simplified
+        functions.append({"name": name, "args": args, "return_type": return_type})
+
+    return {
+        "file_name": file_name,
+        "modules_used": modules_used,
+        "subroutines": subroutines,
+        "functions": functions,
+        "module_variables": module_variables,
+    }
+
+def generate_markdown(parsed_data, template_with_placeholders):
+    """
+    Generates Markdown documentation from parsed Fortran data using a template.
+    """
+    if not parsed_data:
+        return None
+
+    # Perform replacements of placeholders for code blocks
+    current_template = template_with_placeholders.replace("FORTRAN_CODE_BLOCK_START", "! --- Start Fortran Example ---")
+    current_template = current_template.replace("FORTRAN_CODE_BLOCK_END", "! --- End Fortran Example ---")
+
+    file_name = parsed_data["file_name"]
+
+    modules_used_list_md = "\n".join(f"*   `{mod}`" for mod in parsed_data["modules_used"]) \
+        if parsed_data["modules_used"] else "None."
+
+    subroutines_md = []
+    for sub in parsed_data["subroutines"]:
+        arg_list = ", ".join(sub["args"])
+        subroutines_md.append(f"*   **{sub['name']}**({arg_list}): *Brief description placeholder.*")
+
+    functions_md = []
+    for func in parsed_data["functions"]:
+        arg_list = ", ".join(func["args"])
+        # For now, return type is basic.
+        functions_md.append(f"*   **{func['name']}**({arg_list}) (returns {func['return_type']}): *Brief description placeholder.*")
+
+    subroutines_functions_list_md = "\n".join(subroutines_md + functions_md) \
+        if (subroutines_md + functions_md) else "None."
+
+    module_variables_list_md = "\n".join(f"*   **{var['name']}** ({var['type']}): *Description placeholder.*" \
+                                         for var in parsed_data["module_variables"]) \
+        if parsed_data["module_variables"] else "None."
+
+    modules_used_comma_separated_md = ", ".join(f"`{mod}`" for mod in parsed_data["modules_used"]) \
+        if parsed_data["modules_used"] else "None."
+
+    # Populate template
+    markdown_content = current_template.format(
+        file_name=file_name,
+        modules_used_list=modules_used_list_md,
+        subroutines_functions_list=subroutines_functions_list_md,
+        module_variables_list=module_variables_list_md,
+        modules_used_list_comma_separated=modules_used_comma_separated_md
+    )
+    return markdown_content
+
+MARKDOWN_TEMPLATE_WITH_PLACEHOLDERS = """\
+# {{file_name}} - Code Documentation
+
+## Overview
+
+*Please provide a brief description of what this code file does and its role within the larger project.*
+
+## Key Components
+
+### Modules Used
+{{modules_used_list}}
+
+### Subroutines/Functions Defined
+{{subroutines_functions_list}}
+
+## Important Variables/Constants
+{{module_variables_list}}
+
+## Usage Examples
+
+*Please provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.*
+
+FORTRAN_CODE_BLOCK_START
+! Example code snippet
+FORTRAN_CODE_BLOCK_END
+
+## Dependencies and Interactions
+
+*   **Internal Dependencies:**
+    *   Relies on modules: {{modules_used_list_comma_separated}}
+    *   *(Add other specific interactions if known)*
+*   **External Libraries:**
+    *   *(Specify if any external libraries are directly used and not via other project modules)*
+
+---
+*Documentation generated by AI assistant. Please review and enhance.*
+"""
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Markdown documentation from Fortran source files.")
+    parser.add_argument("fortran_file", help="Path to the Fortran source file.")
+    args = parser.parse_args()
+
+    fortran_filepath = args.fortran_file
+
+    # Create docs/markdown directory if it doesn't exist
+    output_dir = "docs/markdown"
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Parse the Fortran file
+    parsed_data = parse_fortran_file(fortran_filepath)
+
+    if not parsed_data:
+        print(f"Failed to parse {fortran_filepath}. Exiting.")
+        return
+
+    # Generate Markdown content
+    markdown_content = generate_markdown(parsed_data, MARKDOWN_TEMPLATE_WITH_PLACEHOLDERS)
+
+    if not markdown_content:
+        print("Failed to generate Markdown content. Exiting.")
+        return
+
+    # Determine output filename
+    base_name = parsed_data["file_name"]
+    output_filename = os.path.splitext(base_name)[0] + ".md"
+    output_filepath = os.path.join(output_dir, output_filename)
+
+    # Write the Markdown content to the output file
+    try:
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+        print(f"Successfully generated documentation: {output_filepath}")
+    except Exception as e:
+        print(f"Error writing Markdown file {output_filepath}: {e}")
+
+if __name__ == "__main__":
+    main()
+```


### PR DESCRIPTION
This commit introduces Markdown documentation for the `atom_mod.F` module, located at `docs/markdown/atom_mod.md`.

I created the documentation manually based on a predefined template due to persistent `SyntaxError` issues in the execution environment that prevented the `generate_doc.py` script from running.

The `atom_mod.F` module primarily defines a large number of shared parameters and allocatable arrays crucial for atomic calculations within the application. This documentation provides an overview, lists key (selected) variables, and gives a general idea of its usage and dependencies.